### PR TITLE
Update 06-04-01-Containers.md

### DIFF
--- a/_posts/06-04-01-Containers.md
+++ b/_posts/06-04-01-Containers.md
@@ -4,14 +4,14 @@ isChild: true
 anchor:  containers
 ---
 
-## Composants {#containers_title}
+## Conteneur {#containers_title}
 
-La première chose que vous devriez comprendre sur les composants d'injection de dépendances est qu'il ne s'agit pas de 
-la même chose que l'injection de dépendances. Un composant est un moyen pratique d'implémenter l'injection de dépendances, 
+La première chose que vous devriez comprendre sur les conteneurs d'injection de dépendances est qu'il ne s'agit pas de 
+la même chose que l'injection de dépendances. Un conteneur est un moyen pratique d'implémenter l'injection de dépendances, 
 cependant, ils peuvent être souvent mal utilisés et devenir un anti-pattern. Injecter un composant ID en tant que 
 localisateur de services à l'intérieur de vos classes crée sans aucun doute une dépendance plus forte que la dépendance 
 que vous remplacez. Cela rend aussi votre code moins transparent et finalement plus dur à tester.
 
-La plupart des frameworks modernes ont leur propres composants d'injection de dépendances qui permettent de brancher 
+La plupart des frameworks modernes ont leur propre conteneur d'injection de dépendances qui permettent de brancher 
 vos dépendances ensemble à travers un fichier de configuration. Cela signifie en pratique que vous écrivez du code métier 
 aussi propre et découplé que le framework sur lequel vous vous basez.


### PR DESCRIPTION
https://fr.wikipedia.org/wiki/Conteneur_(informatique)
traduire container par conteneur me semble plus approprié que de le traduire par composant. Surtout pour éviter l'ambiguité avec le composant traduction de "component"
