### PR TITLE
Change The PHP Mentoring URL to the Resources.md File

### DIFF
--- a/_posts/16-01-01-Resources.md
+++ b/_posts/16-01-01-Resources.md
@@ -24,7 +24,7 @@ anchor: resources
 
 ## Mentorat
 
-* [phpmentoring.org](http://phpmentoring.org/) - Encadrement et montée en compétences par des membres de la communauté
+* [phpmentoring.org](http://php-mentoring.org/) - Encadrement et montée en compétences par des membres de la communauté
 
 ## Fournisseurs PaaS pour PHP
 


### PR DESCRIPTION
### Modification de l'URL de PHP Mentoring

J'étais sur le site et j'ai remarqué que le lien de la ressource qui mène vers le site de PHP Mentoring n'était pas le bon alors j'ai décidé de le modifier. Vous faites du très bon boulot et j'aimerais faire partie de l'aventure. C'est avec plaisir que je propose modification aussi petit qu'elle soit. 
Merci @eilgin tu as fait du très bon boulot pour la communauté francophone.